### PR TITLE
Ensure attestation has at most one classification

### DIFF
--- a/consultation/src/commonMain/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/IsChainTrustedForAttestation.kt
+++ b/consultation/src/commonMain/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/IsChainTrustedForAttestation.kt
@@ -151,36 +151,62 @@ public data class AttestationClassifications(
     val qEAAs: AttestationIdentifierPredicate = AttestationIdentifierPredicate.None,
     val eaAs: Map<String, AttestationIdentifierPredicate> = emptyMap(),
 ) {
+
     /**
-     * Creates a function that classifies an [AttestationIdentifier] into one of the given categories,
-     * and then uses the given mappings functions to map the identifier to a result of type [T].
+     * Classifies an attestation identifier using the configured predicates.
+     * At most one match is expected.
      *
-     * @param ifPid the mapping function to use for PIDs
-     * @param ifPubEaa the mapping function to use for public EAA identifiers
-     * @param ifQEaa the mapping function to use for qualified EAA identifiers
-     * @param ifEaa the mapping function to use for EAA identifiers with a specific use case
-     *
-     * @return a function that classifies an [AttestationIdentifier] into one of the given categories,
-     * and then provides a result of type [T] based on the classification.
-     * If the [AttestationIdentifier] is not classified, returns null.
-     *
-     * @param T the type of the result of the mapping function
+     * @param identifier the attestation identifier to classify.
+     * @return the classification of the given identifier, or null if the identifier does not match any predicate.
+     * @throws IllegalStateException if the identifier matches multiple predicates.
      */
-    public fun <T : Any> classifyAndMap(
-        ifPid: () -> T,
-        ifPubEaa: () -> T,
-        ifQEaa: () -> T,
-        ifEaa: (String) -> T,
-    ): (AttestationIdentifier) -> T? = { identifier ->
-        when {
-            pids.test(identifier) -> ifPid()
-            pubEAAs.test(identifier) -> ifPubEaa()
-            qEAAs.test(identifier) -> ifQEaa()
-            else -> {
-                eaAs.firstNotNullOfOrNull { (useCase, predicate) ->
-                    if (predicate.test(identifier)) ifEaa(useCase) else null
-                }
+    @Throws(IllegalStateException::class)
+    public fun classify(identifier: AttestationIdentifier): Match? {
+        val matches = match(identifier)
+        check(matches.size <= 1) {
+            "AttestationIdentifier $identifier matches multiple predicates: ${matches.joinToString()}"
+        }
+        return matches.firstOrNull()
+    }
+
+    /**
+     * Matches an attestation identifier using the configured predicates.
+     * Normally, at most one match is expected.
+     * If multiple matches are found, this is a signed of an
+     * invalid configuration of the [AttestationClassifications] instance.
+     *
+     * @param identifier the attestation identifier to classify.
+     * @return a list of matches for the given identifier
+     */
+    public fun match(identifier: AttestationIdentifier): List<Match> =
+        buildList {
+            if (pids.test(identifier)) add(Match.PID)
+            if (pubEAAs.test(identifier)) add(Match.PubEAA)
+            if (qEAAs.test(identifier)) add(Match.QEAA)
+            eaAs.forEach { (useCase, predicate) ->
+                if (predicate.test(identifier)) add(Match.EAA(useCase))
             }
+        }
+
+    /**
+     * Represents the classification of an attestation identifier
+     */
+    public sealed interface Match {
+        public object PID : Match
+        public object PubEAA : Match
+        public object QEAA : Match
+        public data class EAA(val useCase: String) : Match
+
+        public fun <T> fold(
+            ifPid: T,
+            ifPubEaa: T,
+            ifQEaa: T,
+            ifEaa: (String) -> T,
+        ): T = when (this) {
+            PID -> ifPid
+            PubEAA -> ifPubEaa
+            QEAA -> ifQEaa
+            is EAA -> ifEaa(useCase)
         }
     }
 }
@@ -194,15 +220,23 @@ public data class AttestationClassifications(
  */
 public class IsChainTrustedForAttestation<in CHAIN : Any, TRUST_ANCHOR : Any>(
     private val isChainTrustedForContext: suspend (CHAIN, VerificationContext) -> CertificationChainValidation<TRUST_ANCHOR>?,
-    classifications: AttestationClassifications,
+    private val classifications: AttestationClassifications,
 ) {
 
-    private val issuanceAndRevocationContextOf: (AttestationIdentifier) -> Pair<VerificationContext, VerificationContext>? =
-        classifications.classifyAndMap(
-            ifPid = { VerificationContext.PID to VerificationContext.PIDStatus },
-            ifPubEaa = { VerificationContext.PubEAA to VerificationContext.PubEAAStatus },
-            ifQEaa = { VerificationContext.QEAA to VerificationContext.QEAAStatus },
-            ifEaa = { useCase -> VerificationContext.EAA(useCase) to VerificationContext.EAAStatus(useCase) },
+    private fun issuanceOf(identifier: AttestationIdentifier): VerificationContext? =
+        classifications.classify(identifier)?.fold(
+            ifPid = VerificationContext.PID,
+            ifPubEaa = VerificationContext.PubEAA,
+            ifQEaa = VerificationContext.QEAA,
+            ifEaa = { useCase: String -> VerificationContext.EAA(useCase) },
+        )
+
+    private fun revocationContextOf(identifier: AttestationIdentifier): VerificationContext? =
+        classifications.classify(identifier)?.fold(
+            ifPid = VerificationContext.PIDStatus,
+            ifPubEaa = VerificationContext.PubEAAStatus,
+            ifQEaa = VerificationContext.QEAAStatus,
+            ifEaa = { useCase: String -> VerificationContext.EAAStatus(useCase) },
         )
 
     /**
@@ -211,14 +245,15 @@ public class IsChainTrustedForAttestation<in CHAIN : Any, TRUST_ANCHOR : Any>(
      * @param chain the certificate chain to be validated
      * @param identifier the attestation identifier
      * @return the result of the validation
+     *
+     * @throws IllegalStateException if the identifier matches multiple classifications
      */
+    @Throws(IllegalStateException::class)
     public suspend fun issuance(
         chain: CHAIN,
         identifier: AttestationIdentifier,
     ): CertificationChainValidation<TRUST_ANCHOR>? =
-        issuanceAndRevocationContextOf(identifier)?.let { (issuance, _) ->
-            isChainTrustedForContext(chain, issuance)
-        }
+        issuanceOf(identifier)?.let { isChainTrustedForContext(chain, it) }
 
     /**
      * Validates a certificate chain for revocation of an attestation.
@@ -226,12 +261,13 @@ public class IsChainTrustedForAttestation<in CHAIN : Any, TRUST_ANCHOR : Any>(
      * @param chain the certificate chain to be validated
      * @param identifier the attestation identifier
      * @return the result of the validation
+     *
+     * @throws IllegalStateException if the identifier matches multiple classifications
      */
+    @Throws(IllegalStateException::class)
     public suspend fun revocation(
         chain: CHAIN,
         identifier: AttestationIdentifier,
     ): CertificationChainValidation<TRUST_ANCHOR>? =
-        issuanceAndRevocationContextOf(identifier)?.let { (_, revocation) ->
-            isChainTrustedForContext(chain, revocation)
-        }
+        revocationContextOf(identifier)?.let { isChainTrustedForContext(chain, it) }
 }

--- a/consultation/src/commonTest/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/AttestationClassificationsTest.kt
+++ b/consultation/src/commonTest/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/AttestationClassificationsTest.kt
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.etsi1196x2.consultation
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class AttestationClassificationsTest {
+
+    private val pidMDoc = MDoc(docType = "eu.europa.ec.eudi.pid.1")
+    private val pidSdJwt = SDJwtVc(vct = "urn:eudi:pid:1")
+    private val mdl = MDoc(docType = "org.iso.18013.5.1.mDL")
+    private val loyaltyCard = SDJwtVc(vct = "https://example.com/loyalty")
+
+    // Test classify method - basic functionality
+
+    @Test
+    fun `classify returns null when no predicates match`() {
+        val classifications = AttestationClassifications()
+
+        assertNull(classifications.classify(pidMDoc))
+        assertNull(classifications.classify(mdl))
+        assertNull(classifications.classify(loyaltyCard))
+    }
+
+    @Test
+    fun `classify returns PID match`() {
+        val classifications = AttestationClassifications(
+            pids = pidMDoc.predicate,
+        )
+
+        assertEquals(AttestationClassifications.Match.PID, classifications.classify(pidMDoc))
+        assertNull(classifications.classify(mdl))
+    }
+
+    @Test
+    fun `classify returns PubEAA match`() {
+        val classifications = AttestationClassifications(
+            pubEAAs = loyaltyCard.predicate,
+        )
+
+        assertEquals(AttestationClassifications.Match.PubEAA, classifications.classify(loyaltyCard))
+        assertNull(classifications.classify(pidMDoc))
+    }
+
+    @Test
+    fun `classify returns QEAA match`() {
+        val classifications = AttestationClassifications(
+            qEAAs = mdl.predicate,
+        )
+
+        assertEquals(AttestationClassifications.Match.QEAA, classifications.classify(mdl))
+        assertNull(classifications.classify(pidMDoc))
+    }
+
+    @Test
+    fun `classify returns EAA match with use case`() {
+        val classifications = AttestationClassifications(
+            eaAs = mapOf("mdl" to mdl.predicate),
+        )
+
+        assertEquals(AttestationClassifications.Match.EAA("mdl"), classifications.classify(mdl))
+        assertNull(classifications.classify(pidMDoc))
+    }
+
+    @Test
+    fun `classify works with combined predicates using or`() {
+        val classifications = AttestationClassifications(
+            pids = pidMDoc.predicate or pidSdJwt.predicate,
+        )
+
+        assertEquals(AttestationClassifications.Match.PID, classifications.classify(pidMDoc))
+        assertEquals(AttestationClassifications.Match.PID, classifications.classify(pidSdJwt))
+        assertNull(classifications.classify(mdl))
+    }
+
+    @Test
+    fun `classify works with regex predicates`() {
+        val classifications = AttestationClassifications(
+            pids = AttestationIdentifierPredicate.mdocMatching(Regex("eu\\.europa\\.ec\\.eudi\\.pid\\..*")),
+            eaAs = mapOf("mdl" to AttestationIdentifierPredicate.mdocMatching(Regex("org\\.iso\\.18013\\..*"))),
+        )
+
+        assertEquals(AttestationClassifications.Match.PID, classifications.classify(pidMDoc))
+        assertEquals(AttestationClassifications.Match.EAA("mdl"), classifications.classify(mdl))
+        assertNull(classifications.classify(pidSdJwt))
+    }
+
+    @Test
+    fun `classify works with any predicate`() {
+        val classifications = AttestationClassifications(
+            pids = AttestationIdentifierPredicate.any(setOf(pidMDoc, pidSdJwt)),
+        )
+
+        assertEquals(AttestationClassifications.Match.PID, classifications.classify(pidMDoc))
+        assertEquals(AttestationClassifications.Match.PID, classifications.classify(pidSdJwt))
+        assertNull(classifications.classify(mdl))
+    }
+
+    // Test classify method - at-most-one match guarantee
+
+    @Test
+    fun `classify throws when identifier matches PID and PubEAA`() {
+        val classifications = AttestationClassifications(
+            pids = mdl.predicate,
+            pubEAAs = mdl.predicate,
+        )
+
+        assertFailsWith<IllegalStateException> {
+            classifications.classify(mdl)
+        }
+    }
+
+    @Test
+    fun `classify throws when identifier matches PID and QEAA`() {
+        val classifications = AttestationClassifications(
+            pids = mdl.predicate,
+            qEAAs = mdl.predicate,
+        )
+
+        assertFailsWith<IllegalStateException> {
+            classifications.classify(mdl)
+        }
+    }
+
+    @Test
+    fun `classify throws when identifier matches PubEAA and QEAA`() {
+        val classifications = AttestationClassifications(
+            pubEAAs = mdl.predicate,
+            qEAAs = mdl.predicate,
+        )
+
+        assertFailsWith<IllegalStateException> {
+            classifications.classify(mdl)
+        }
+    }
+
+    @Test
+    fun `classify throws when identifier matches QEAA and EAA`() {
+        val classifications = AttestationClassifications(
+            qEAAs = mdl.predicate,
+            eaAs = mapOf("mdl" to mdl.predicate),
+        )
+
+        assertFailsWith<IllegalStateException> {
+            classifications.classify(mdl)
+        }
+    }
+
+    @Test
+    fun `classify throws when identifier matches multiple EAA use cases`() {
+        val classifications = AttestationClassifications(
+            eaAs = mapOf(
+                "mdl" to mdl.predicate,
+                "driving_license" to mdl.predicate,
+            ),
+        )
+
+        assertFailsWith<IllegalStateException> {
+            classifications.classify(mdl)
+        }
+    }
+
+    @Test
+    fun `classify throws when identifier matches all categories`() {
+        val classifications = AttestationClassifications(
+            pids = mdl.predicate,
+            pubEAAs = mdl.predicate,
+            qEAAs = mdl.predicate,
+            eaAs = mapOf("mdl" to mdl.predicate),
+        )
+
+        assertFailsWith<IllegalStateException> {
+            classifications.classify(mdl)
+        }
+    }
+
+    // Test match method - diagnostic functionality
+
+    @Test
+    fun `match returns empty list when no predicates match`() {
+        val classifications = AttestationClassifications()
+
+        assertContentEquals(emptyList(), classifications.match(pidMDoc))
+    }
+
+    @Test
+    fun `match returns single match when exactly one predicate matches`() {
+        val classifications = AttestationClassifications(
+            pids = pidMDoc.predicate,
+        )
+
+        assertContentEquals(
+            listOf(AttestationClassifications.Match.PID),
+            classifications.match(pidMDoc),
+        )
+    }
+
+    @Test
+    fun `match returns all matches for misconfigured predicates`() {
+        val classifications = AttestationClassifications(
+            pids = mdl.predicate,
+            pubEAAs = mdl.predicate,
+            qEAAs = mdl.predicate,
+        )
+
+        val matches = classifications.match(mdl)
+        assertEquals(3, matches.size)
+        assertContentEquals(
+            listOf(
+                AttestationClassifications.Match.PID,
+                AttestationClassifications.Match.PubEAA,
+                AttestationClassifications.Match.QEAA,
+            ),
+            matches,
+        )
+    }
+
+    @Test
+    fun `match returns multiple EAA matches when misconfigured`() {
+        val classifications = AttestationClassifications(
+            eaAs = mapOf(
+                "mdl" to mdl.predicate,
+                "driving_license" to mdl.predicate,
+                "vehicle" to mdl.predicate,
+            ),
+        )
+
+        val matches = classifications.match(mdl)
+        assertEquals(3, matches.size)
+        assertContentEquals(
+            listOf(
+                AttestationClassifications.Match.EAA("mdl"),
+                AttestationClassifications.Match.EAA("driving_license"),
+                AttestationClassifications.Match.EAA("vehicle"),
+            ),
+            matches,
+        )
+    }
+}


### PR DESCRIPTION
The PR adds a critical check to the `AttestationClassifications`.

Now, when an attestation is being classified, there is a check that it matches at most one category (PID, PUB EAA, QEAA, EAA, etc)

