### PR TITLE
Fix resource safety issues

### DIFF
--- a/consultation/src/commonMain/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/GetTrustAnchors.kt
+++ b/consultation/src/commonMain/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/GetTrustAnchors.kt
@@ -164,6 +164,7 @@ public class GetTrustAnchorsCachedSource<in QUERY : Any, out TRUST_ANCHOR : Any>
 
     override fun close() {
         cached.close()
+        delegate.closeIfNeeded()
     }
 }
 

--- a/consultation/src/commonMain/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/IsChainTrustedForContext.kt
+++ b/consultation/src/commonMain/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/IsChainTrustedForContext.kt
@@ -58,7 +58,7 @@ public fun interface IsChainTrustedForContextF<in CHAIN : Any, in CTX : Any, out
 public class IsChainTrustedForContext<in CHAIN : Any, CTX : Any, out TRUST_ANCHOR : Any>(
     private val validateCertificateChain: ValidateCertificateChain<CHAIN, TRUST_ANCHOR>,
     private val getTrustAnchorsByContext: GetTrustAnchorsForSupportedQueries<CTX, TRUST_ANCHOR>,
-) : IsChainTrustedForContextF<CHAIN, CTX, TRUST_ANCHOR>, AutoCloseable {
+) : IsChainTrustedForContextF<CHAIN, CTX, TRUST_ANCHOR>, AutoCloseable by getTrustAnchorsByContext {
 
     /**
      * Check certificate chain is trusted in the context of
@@ -121,10 +121,6 @@ public class IsChainTrustedForContext<in CHAIN : Any, CTX : Any, out TRUST_ANCHO
                 IsChainTrustedForContext(validateCertificateChain, it)
             }
         }
-
-    override fun close() {
-        getTrustAnchorsByContext.close()
-    }
 
     public companion object
 }

--- a/consultation/src/commonMain/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/UnsafeIsChainTrustedForContext.kt
+++ b/consultation/src/commonMain/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/UnsafeIsChainTrustedForContext.kt
@@ -31,7 +31,7 @@ import kotlinx.coroutines.withContext
 internal class UnsafeIsChainTrustedForContext<in CHAIN : Any, CTX : Any, out TRUST_ANCHOR : Any>(
     private val primary: IsChainTrustedForContext<CHAIN, CTX, TRUST_ANCHOR>,
     private val recovery: (CertificationChainValidation.NotTrusted) -> IsChainTrustedForContext<CHAIN, CTX, TRUST_ANCHOR>?,
-) : IsChainTrustedForContextF<CHAIN, CTX, TRUST_ANCHOR> {
+) : IsChainTrustedForContextF<CHAIN, CTX, TRUST_ANCHOR>, AutoCloseable {
 
     /**
      * Check certificate chain is trusted in the context of
@@ -59,5 +59,9 @@ internal class UnsafeIsChainTrustedForContext<in CHAIN : Any, CTX : Any, out TRU
         verificationContext: CTX,
         notTrusted: CertificationChainValidation.NotTrusted,
     ): CertificationChainValidation<TRUST_ANCHOR>? =
-        recovery(notTrusted)?.let { fallback -> fallback(chain, verificationContext) }
+        recovery(notTrusted)?.use { fallback -> fallback(chain, verificationContext) }
+
+    override fun close() {
+        primary.close()
+    }
 }

--- a/consultation/src/commonTest/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/GetTrustAnchorsForSupportedQueriesTest.kt
+++ b/consultation/src/commonTest/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/GetTrustAnchorsForSupportedQueriesTest.kt
@@ -20,6 +20,42 @@ import kotlin.test.*
 
 class GetTrustAnchorsForSupportedQueriesTest {
 
+    private class MockAutoCloseableGetTrustAnchors(
+        val result: NonEmptyList<String>? = null,
+    ) : GetTrustAnchors<String, String>, AutoCloseable {
+        var closed = false
+        override suspend fun invoke(query: String): NonEmptyList<String>? = result
+        override fun close() {
+            closed = true
+        }
+    }
+
+    @Test
+    fun testClose() {
+        val source1 = MockAutoCloseableGetTrustAnchors()
+        val source2 = MockAutoCloseableGetTrustAnchors()
+        val supportedQueries = GetTrustAnchorsForSupportedQueries(setOf("q1"), source1) plus (setOf("q2") to source2)
+
+        supportedQueries.close()
+
+        assertTrue(source1.closed, "Source 1 should be closed")
+        assertTrue(source2.closed, "Source 2 should be closed")
+    }
+
+    @Test
+    fun testTransformClose() {
+        val source = MockAutoCloseableGetTrustAnchors()
+        val supportedQueries = GetTrustAnchorsForSupportedQueries(setOf("q1"), source)
+        val transformed = supportedQueries.transform(
+            contraMapF = { s: String -> s },
+            mapF = { s: String -> s },
+        )
+
+        transformed.close()
+
+        assertTrue(source.closed, "Underlying source should be closed")
+    }
+
     private fun mockSource(value: String): GetTrustAnchors<String, String> = GetTrustAnchors { _ ->
         NonEmptyList(listOf(value))
     }

--- a/consultation/src/commonTest/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/GetTrustAnchorsTest.kt
+++ b/consultation/src/commonTest/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/GetTrustAnchorsTest.kt
@@ -16,11 +16,53 @@
 package eu.europa.ec.eudi.etsi1196x2.consultation
 
 import kotlinx.coroutines.test.runTest
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
+import kotlin.test.*
+import kotlin.time.Duration
 
 class GetTrustAnchorsTest {
+
+    private class MockAutoCloseableGetTrustAnchors(
+        val result: NonEmptyList<String>? = null,
+    ) : GetTrustAnchors<String, String>, AutoCloseable {
+        var closed = false
+        override suspend fun invoke(query: String): NonEmptyList<String>? = result
+        override fun close() {
+            closed = true
+        }
+    }
+
+    @Test
+    @SensitiveApi
+    fun `or combinator closes both sources`() {
+        val source1 = MockAutoCloseableGetTrustAnchors()
+        val source2 = MockAutoCloseableGetTrustAnchors()
+        val combined = source1 or source2
+
+        (combined as AutoCloseable).close()
+
+        assertTrue(source1.closed, "Source 1 should be closed")
+        assertTrue(source2.closed, "Source 2 should be closed")
+    }
+
+    @Test
+    fun `contraMap closes underlying source`() {
+        val source = MockAutoCloseableGetTrustAnchors()
+        val adapted = source.contraMap<String, String, Int> { it.toString() }
+
+        (adapted as AutoCloseable).close()
+
+        assertTrue(source.closed, "Underlying source should be closed")
+    }
+
+    @Test
+    fun `cached closes underlying source`() = runTest {
+        val source = MockAutoCloseableGetTrustAnchors()
+        val cached = source.cached(ttl = Duration.INFINITE, expectedQueries = 1)
+
+        cached.close()
+
+        assertTrue(source.closed, "Underlying source should be closed")
+    }
 
     @Test
     @SensitiveApi

--- a/consultation/src/commonTest/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/IsChainTrustedForContextTest.kt
+++ b/consultation/src/commonTest/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/IsChainTrustedForContextTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.etsi1196x2.consultation
+
+import kotlin.test.*
+
+class IsChainTrustedForContextTest {
+
+    private class MockAutoCloseableGetTrustAnchors : GetTrustAnchors<String, String>, AutoCloseable {
+        var closed = false
+        override suspend fun invoke(query: String): NonEmptyList<String>? = null
+        override fun close() {
+            closed = true
+        }
+    }
+
+    @Test
+    fun testClose() {
+        val validateCertificateChain = ValidateCertificateChain<String, String> { _, _ ->
+            CertificationChainValidation.NotTrusted(RuntimeException())
+        }
+        val source = MockAutoCloseableGetTrustAnchors()
+        val getTrustAnchorsByContext = GetTrustAnchorsForSupportedQueries(setOf("ctx1"), source)
+        val isChainTrusted = IsChainTrustedForContext(validateCertificateChain, getTrustAnchorsByContext)
+
+        isChainTrusted.close()
+
+        assertTrue(source.closed, "Underlying source should be closed")
+    }
+
+    @Test
+    fun testContraMapClose() {
+        val validateCertificateChain = ValidateCertificateChain<String, String> { _, _ ->
+            CertificationChainValidation.NotTrusted(RuntimeException())
+        }
+        val source = MockAutoCloseableGetTrustAnchors()
+        val getTrustAnchorsByContext = GetTrustAnchorsForSupportedQueries(setOf("ctx1"), source)
+        val isChainTrusted = IsChainTrustedForContext(validateCertificateChain, getTrustAnchorsByContext)
+
+        val contraMapped = isChainTrusted.contraMap<Int> { it.toString() }
+        contraMapped.close()
+
+        assertTrue(source.closed, "Underlying source should be closed after contraMap and close")
+    }
+
+    @Test
+    @SensitiveApi
+    fun testRecoverWithClose() {
+        val validateCertificateChain = ValidateCertificateChain<String, String> { _, _ ->
+            CertificationChainValidation.NotTrusted(RuntimeException())
+        }
+        val source = MockAutoCloseableGetTrustAnchors()
+        val getTrustAnchorsByContext = GetTrustAnchorsForSupportedQueries(setOf("ctx1"), source)
+        val isChainTrusted = IsChainTrustedForContext(validateCertificateChain, getTrustAnchorsByContext)
+
+        val recovered = isChainTrusted.recoverWith { _ -> null }
+        (recovered as AutoCloseable).close()
+
+        assertTrue(source.closed, "Underlying source should be closed after recoverWith and close")
+    }
+}


### PR DESCRIPTION
- **Annotate APIs and add implementations for fallback and query transformation in `GetTrustAnchors`.**
- **Implement `AutoCloseable` for various test and production classes, ensuring proper resource management**
