### PR TITLE
Upgrade android plugin to 8.12.2

### DIFF
--- a/119602-consultation/build.gradle.kts
+++ b/119602-consultation/build.gradle.kts
@@ -94,12 +94,14 @@ kotlin {
             }
         }
 
+        @Suppress("UNUSED")
         val jvmAndAndroidMain by getting {
             dependencies {
                 implementation(libs.bouncy.castle)
             }
         }
 
+        @Suppress("UNUSED")
         val jvmAndAndroidTest by getting {
             dependencies {
                 implementation(libs.ktor.client.java)
@@ -194,7 +196,6 @@ mavenPublishing {
         KotlinMultiplatform(
             javadocJar = JavadocJar.Dokka(tasks.dokkaGeneratePublicationHtml),
             sourcesJar = true,
-            androidVariantsToPublish = listOf("release"),
         ),
     )
 

--- a/consultation-dss/build.gradle.kts
+++ b/consultation-dss/build.gradle.kts
@@ -85,6 +85,8 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.test)
             }
         }
+
+        @Suppress("UNUSED")
         val jvmAndAndroidMain by getting {
             dependencies {
                 api(project.dependencies.platform(libs.dss.bom))
@@ -95,6 +97,7 @@ kotlin {
             }
         }
 
+        @Suppress("UNUSED")
         val jvmAndAndroidTest by getting {
             dependencies {
                 implementation(libs.dss.utils.guava)
@@ -177,7 +180,6 @@ mavenPublishing {
         KotlinMultiplatform(
             javadocJar = JavadocJar.Dokka(tasks.dokkaGeneratePublicationHtml),
             sourcesJar = true,
-            androidVariantsToPublish = listOf("release"),
         ),
     )
 

--- a/consultation/build.gradle.kts
+++ b/consultation/build.gradle.kts
@@ -81,6 +81,7 @@ kotlin {
             }
         }
 
+        @Suppress("UNUSED")
         val jvmAndAndroidMain by getting {
             dependencies {
                 implementation(libs.bouncy.castle)
@@ -176,7 +177,6 @@ mavenPublishing {
         KotlinMultiplatform(
             javadocJar = JavadocJar.Dokka(tasks.dokkaGeneratePublicationHtml),
             sourcesJar = true,
-            androidVariantsToPublish = listOf("release"),
         ),
     )
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 java = "17"
 kotlin = "2.2.21"
-android-library = "8.5.2"
+android-library = "8.12.2"
 kotlinx-serialization = "1.9.0"
 kotlinx-coroutines = "1.10.2"
 kotlinx-datetime = "0.7.1"


### PR DESCRIPTION
- **Suppress warnings and remove unused `androidVariantsToPublish` configuration**
- **Bump android-library version to 8.12.2 in libs.versions.toml**
