### PR TITLE
Align verification contexts to TS3 v1.5

### DIFF
--- a/119602-consultation/src/commonMain/kotlin/eu/europa/ec/eudi/etsi119602/consultation/EUSupportedLists.kt
+++ b/119602-consultation/src/commonMain/kotlin/eu/europa/ec/eudi/etsi119602/consultation/EUSupportedLists.kt
@@ -35,7 +35,7 @@ public fun SupportedLists.Companion.eu(): SupportedLists<LotEMeta<VerificationCo
         ),
         walletProviders = UseCase.WalletAttestation.loteMeta(
             issuance = VerificationContext.WalletProviderAttestation,
-            revocation = VerificationContext.WalletProviderAttestationStatus,
+            revocation = VerificationContext.WalletOrKeyStorageStatus,
         ),
 
         wrpacProviders = UseCase.WRPAC.loteMeta(

--- a/119602-consultation/src/commonMain/kotlin/eu/europa/ec/eudi/etsi119602/consultation/EUSupportedLists.kt
+++ b/119602-consultation/src/commonMain/kotlin/eu/europa/ec/eudi/etsi119602/consultation/EUSupportedLists.kt
@@ -30,25 +30,22 @@ import kotlin.time.Instant
 public fun SupportedLists.Companion.eu(): SupportedLists<LotEMeta<VerificationContext>> =
     SupportedLists(
         pidProviders = UseCase.PID.loteMeta(
-            issuance = setOf(VerificationContext.PID),
-            revocation = setOf(VerificationContext.PIDStatus),
+            issuance = VerificationContext.PID,
+            revocation = VerificationContext.PIDStatus,
         ),
         walletProviders = UseCase.WalletAttestation.loteMeta(
-            issuance = setOf(
-                VerificationContext.WalletInstanceAttestation,
-                VerificationContext.WalletUnitAttestation,
-            ),
-            revocation = setOf(VerificationContext.WalletUnitAttestationStatus),
+            issuance = VerificationContext.WalletProviderAttestation,
+            revocation = VerificationContext.WalletProviderAttestationStatus,
         ),
 
         wrpacProviders = UseCase.WRPAC.loteMeta(
-            issuance = setOf(VerificationContext.WalletRelyingPartyAccessCertificate),
-            revocation = emptySet(),
+            issuance = VerificationContext.WalletRelyingPartyAccessCertificate,
+            revocation = null,
         ),
 
         wrprcProviders = UseCase.WRPC.loteMeta(
-            issuance = setOf(VerificationContext.WalletRelyingPartyRegistrationCertificate),
-            revocation = setOf(VerificationContext.WalletRelyingPartyRegistrationCertificateStatus),
+            issuance = VerificationContext.WalletRelyingPartyRegistrationCertificate,
+            revocation = VerificationContext.WalletRelyingPartyRegistrationCertificateStatus,
         ),
         pubEaaProviders = null,
         qeaProviders = null,
@@ -100,29 +97,29 @@ private data class UseCase(
 }
 
 private fun <CTX : Any> UseCase.loteMeta(
-    issuance: Set<CTX>,
-    revocation: Set<CTX>,
+    issuance: CTX?,
+    revocation: CTX?,
 ): LotEMeta<CTX> = LotEMeta(
     svcTypePerCtx = svcTypePerCtx(issuance, revocation),
     serviceDigitalIdentityCertificateType = loteProfile.trustedEntities.serviceDigitalIdentityCertificateType,
 )
 
 private fun <CTX : Any> UseCase.svcTypePerCtx(
-    issuanceCtxs: Set<CTX>,
-    revocationCtxs: Set<CTX>,
+    issuanceCtx: CTX?,
+    revocationCtx: CTX?,
 ): Map<CTX, LotEMeta.SvcAndEEProfile> =
     when (val serviceTypeIdentifiers = loteProfile.trustedEntities.serviceTypeIdentifiers) {
         is ServiceTypeIdentifiers.OneOrMore -> error("Not supported")
         is ServiceTypeIdentifiers.IssuanceAndRevocation -> {
             buildMap {
-                issuanceCtxs.forEach { ctx ->
+                issuanceCtx?.let { ctx ->
                     val value = LotEMeta.SvcAndEEProfile(
                         serviceTypeIdentifiers.issuance,
                         issuanceCertificateProfile,
                     )
                     put(ctx, value)
                 }
-                revocationCtxs.forEach { ctx ->
+                revocationCtx?.let { ctx ->
                     val value = LotEMeta.SvcAndEEProfile(
                         serviceTypeIdentifiers.revocation,
                         revocationCertificateProfile,

--- a/119602-consultation/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi119602/consultation/DIGIT.kt
+++ b/119602-consultation/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi119602/consultation/DIGIT.kt
@@ -94,7 +94,7 @@ class DIGITTest {
                     VerificationContext.PID,
                     VerificationContext.PIDStatus,
                     VerificationContext.WalletProviderAttestation,
-                    VerificationContext.WalletProviderAttestationStatus,
+                    VerificationContext.WalletOrKeyStorageStatus,
                     VerificationContext.WalletRelyingPartyAccessCertificate,
                     VerificationContext.EAA("mdl"),
                     VerificationContext.EAAStatus("mdl"),

--- a/119602-consultation/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi119602/consultation/DIGIT.kt
+++ b/119602-consultation/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi119602/consultation/DIGIT.kt
@@ -93,9 +93,8 @@ class DIGITTest {
                 listOf(
                     VerificationContext.PID,
                     VerificationContext.PIDStatus,
-                    VerificationContext.WalletInstanceAttestation,
-                    VerificationContext.WalletUnitAttestation,
-                    VerificationContext.WalletUnitAttestationStatus,
+                    VerificationContext.WalletProviderAttestation,
+                    VerificationContext.WalletProviderAttestationStatus,
                     VerificationContext.WalletRelyingPartyAccessCertificate,
                     VerificationContext.EAA("mdl"),
                     VerificationContext.EAAStatus("mdl"),

--- a/119602-consultation/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi119602/consultation/EUDIRefImplEnv.kt
+++ b/119602-consultation/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi119602/consultation/EUDIRefImplEnv.kt
@@ -61,9 +61,8 @@ class EUDIRefImplEnvTest {
                 listOf(
                     VerificationContext.PID,
                     VerificationContext.PIDStatus,
-                    VerificationContext.WalletInstanceAttestation,
-                    VerificationContext.WalletUnitAttestation,
-                    VerificationContext.WalletUnitAttestationStatus,
+                    VerificationContext.WalletProviderAttestation,
+                    VerificationContext.WalletProviderAttestationStatus,
                     VerificationContext.WalletRelyingPartyAccessCertificate,
                     VerificationContext.WalletRelyingPartyRegistrationCertificate,
                     VerificationContext.WalletRelyingPartyRegistrationCertificateStatus,

--- a/119602-consultation/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi119602/consultation/EUDIRefImplEnv.kt
+++ b/119602-consultation/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi119602/consultation/EUDIRefImplEnv.kt
@@ -62,7 +62,7 @@ class EUDIRefImplEnvTest {
                     VerificationContext.PID,
                     VerificationContext.PIDStatus,
                     VerificationContext.WalletProviderAttestation,
-                    VerificationContext.WalletProviderAttestationStatus,
+                    VerificationContext.WalletOrKeyStorageStatus,
                     VerificationContext.WalletRelyingPartyAccessCertificate,
                     VerificationContext.WalletRelyingPartyRegistrationCertificate,
                     VerificationContext.WalletRelyingPartyRegistrationCertificateStatus,

--- a/consultation-dss/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/dss/IsChainTrustedUsingLoTLTest.kt
+++ b/consultation-dss/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/dss/IsChainTrustedUsingLoTLTest.kt
@@ -109,7 +109,7 @@ class IsChainTrustedUsingLoTLTest {
     @Test
     fun verifyThatPidX5CFailsForAnUnsupportedContext() = runTest {
         assertNull(
-            isX5CTrusted(pidX5c, VerificationContext.WalletUnitAttestation),
+            isX5CTrusted(pidX5c, VerificationContext.WalletProviderAttestation),
         )
     }
 }

--- a/consultation/src/commonMain/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/IsChainTrustedForEUDIW.kt
+++ b/consultation/src/commonMain/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/IsChainTrustedForEUDIW.kt
@@ -21,29 +21,21 @@ package eu.europa.ec.eudi.etsi1196x2.consultation
  */
 public sealed interface VerificationContext {
     /**
-     * Check the wallet provider's signature for a Wallet Instance Attestation (WIA)
+     * Check the wallet provider's signature for a Wallet Instance Attestation (WIA) and/or Key Attestation (KA)
      *
      * Can be used by an Authorization Server implementing
      * Attestation-Based Client Authentication
      */
-    public data object WalletInstanceAttestation : VerificationContext
-
-    /**
-     * Check the wallet provider's signature for a Wallet Unit Attestation (WUA)
-     *
-     * Can be used by a Credential Issuer, issuing device-bound attestations
-     * that require WUA
-     */
-    public data object WalletUnitAttestation : VerificationContext
+    public data object WalletProviderAttestation : VerificationContext
 
     /**
      * Check the wallet provider's signature for the Token Status List that keeps
-     * the status of a Wallet Unit Attestation (WUA)
+     * the status of a Wallet Unit Attestation (WUA) or a Key Attestation (KA)
      *
      * Can be used by a Credential Issuer, issuing device-bound attestations
      * to keep track of WUA status
      */
-    public data object WalletUnitAttestationStatus : VerificationContext
+    public data object WalletProviderAttestationStatus : VerificationContext
 
     /**
      * Check PID Provider's signature for a PID

--- a/consultation/src/commonMain/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/IsChainTrustedForEUDIW.kt
+++ b/consultation/src/commonMain/kotlin/eu/europa/ec/eudi/etsi1196x2/consultation/IsChainTrustedForEUDIW.kt
@@ -24,18 +24,21 @@ public sealed interface VerificationContext {
      * Check the wallet provider's signature for a Wallet Instance Attestation (WIA) and/or Key Attestation (KA)
      *
      * Can be used by an Authorization Server implementing
-     * Attestation-Based Client Authentication
+     * Attestation-Based Client Authentication to check the signature of a Wallet Instance Attestation (WIA).
+     * In addition, can be used by a Credential issuer to check the signature of a Key Attestation (KA), during issuance
+     * of device-bound attestations that require Key Attestation (KA)
      */
     public data object WalletProviderAttestation : VerificationContext
 
     /**
      * Check the wallet provider's signature for the Token Status List that keeps
-     * the status of a Wallet Unit Attestation (WUA) or a Key Attestation (KA)
+     * the status of the wallet, located under `client_status` in Wallet Unit Attestation (WUA) or
+     * the status of the keystorage, located under `key_storage.status` in a Key Attestation (KA)
      *
-     * Can be used by a Credential Issuer, issuing device-bound attestations
-     * to keep track of WUA status
+     * Can be used by Credential issuer to check the `client_status` of the Wallet or to check the `key_storage.status`
+     * during issuance of device-bound attestations, that require Key Attestation (KA)
      */
-    public data object WalletProviderAttestationStatus : VerificationContext
+    public data object WalletOrKeyStorageStatus : VerificationContext
 
     /**
      * Check PID Provider's signature for a PID


### PR DESCRIPTION
To the consultation module we have, currently, the following wallet-provider related contexts
 

1. **WalletInstanceAttestation**
2. **WalletUnitAttestation**
3. **WalletUnitAttestationStatus**

TS3 v1.5:
- Changed the term "Wallet Unit Attestation" to "Key Attestation"
- Introduced the `client_status`  to WIA in addition to the status that was found in WUA 

Thus, the PR will use the following
- **WalletProviderAttestation**: This context can be used to verify `x5c` of WIA and KA
- **WalletOrKeyStorageStatus**: This context can be used to verify the `x5c` of Token Status List advertised to the `client_status` of WIA and `key_storage.status` of KA 



