### PR TITLE
Updates tests for Ref. Implementation LoTEs

### DIFF
--- a/119602-consultation/README.md
+++ b/119602-consultation/README.md
@@ -78,6 +78,7 @@ import io.ktor.client.*
 import io.ktor.client.engine.java.*
 import kotlinx.coroutines.*
 import kotlinx.io.files.Path
+import java.nio.file.Files
 import java.security.cert.TrustAnchor
 import java.security.cert.X509Certificate
 import kotlin.time.Duration.Companion.hours
@@ -86,7 +87,7 @@ import kotlin.time.Duration.Companion.minutes
 // 1. Setup HTTP client and file cache
 val httpClient = HttpClient(Java)
 val fileStore = LoTEFileStore(
-    cacheDirectory = Path(System.getProperty("java.io.tmpdir")!!, "lote-cache")
+    cacheDirectory = Path(Files.createTempDirectory("lote-cache").toString())
 )
 val loadLoTE = LoadSingleLoTEWithFileCache(
     fileStore = fileStore,

--- a/119602-consultation/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi119602/consultation/DIGIT.kt
+++ b/119602-consultation/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi119602/consultation/DIGIT.kt
@@ -23,6 +23,7 @@ import eu.europa.ec.eudi.etsi1196x2.consultation.SupportedLists
 import eu.europa.ec.eudi.etsi1196x2.consultation.VerificationContext
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.files.Path
+import java.nio.file.Files
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -79,7 +80,7 @@ class DIGITTest {
     fun testDownload() = runTest {
         createHttpClient().use { httpClient ->
             val fileStore = LoTEFileStore(
-                cacheDirectory = Path(System.getProperty("java.io.tmpdir")!!, "digit-lote"),
+                cacheDirectory = Path(Files.createTempDirectory("digit-lote").toString()),
             )
             val loadLoTE = LoadSingleLoTEWithFileCache(
                 fileStore = fileStore,

--- a/119602-consultation/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi119602/consultation/EUDIRefImplEnv.kt
+++ b/119602-consultation/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi119602/consultation/EUDIRefImplEnv.kt
@@ -130,8 +130,7 @@ class EUDIRefImplEnvTest {
         return provisionTrustAnchors.nonCached(EUDIRefImplEnv.LOTE_URL)
     }
 
-    @Test
-    fun testPidProviderProfile() = pidSigningCertificateProfile().testCertificate(
+    private val pidProviderSigningCertificate =
         """
             -----BEGIN CERTIFICATE-----
             MIIDADCCAqWgAwIBAgIUET5T0Zf8eiEGSYn1U4xFBedGXsswCgYIKoZIzj0EAwIw
@@ -152,11 +151,9 @@ class EUDIRefImplEnvTest {
             PMIZjiKt9xplNamzAoTpv0kCIQCdzmncNLr51HhgGRZiPj7nolhJNoonoH6TkmZu
             pJXe3A==
             -----END CERTIFICATE-----
-        """.trimIndent(),
-    )
+        """.trimIndent()
 
-    @Test
-    fun testWalletProviderProfile() = walletProviderSigningCertificateProfile().testCertificate(
+    private val walletProviderSigningCertificate =
         """
             -----BEGIN CERTIFICATE-----
             MIIDAjCCAqigAwIBAgIUWclZqMVuu3Er5tgW7exeSm1ibAkwCgYIKoZIzj0EAwIw
@@ -177,11 +174,9 @@ class EUDIRefImplEnvTest {
             JLfFee9FJntiQAT4Qh6rnuAhigIhAPhddtIl9ZpNxoVT0deASmgzeTv6lv6aRpAB
             xoZ/gbin
             -----END CERTIFICATE-----
-        """.trimIndent(),
-    )
+        """.trimIndent()
 
-    @Test
-    fun testIssuerAccessCertificate() = wrpAccessCertificateProfile().testCertificate(
+    private val issuerAccessCertificate =
         """
             -----BEGIN CERTIFICATE-----
             MIIDAzCCAqqgAwIBAgIURqZMwltm47FnrUuswJZawUAjTtEwCgYIKoZIzj0EAwIw
@@ -202,11 +197,9 @@ class EUDIRefImplEnvTest {
             oqbvYRbzIbMHoqNh2EUfLjLfsezLAiBPVXyUJQyJ/rE43aVgjB4tX5h8oAuQNEBS
             G9WdPfYDrg==
             -----END CERTIFICATE-----
-        """.trimIndent(),
-    )
+        """.trimIndent()
 
-    @Test
-    fun testVerifierAccessCertificate() = wrpAccessCertificateProfile().testCertificate(
+    private val verifierAccessCertificate =
         """
             -----BEGIN CERTIFICATE-----
             MIIC/TCCAqKgAwIBAgIUK/6I3nrQOiMq/aIqMF7D7vv+xA4wCgYIKoZIzj0EAwIw
@@ -227,14 +220,51 @@ class EUDIRefImplEnvTest {
             XXYfyjgJS2jl6poPBK0CIQDOrjRS9rPbEK3MbUnQdcfZpRHCMeaT5+Fhqb+nrb89
             cw==
             -----END CERTIFICATE-----
-        """.trimIndent(),
-    )
+        """.trimIndent()
+
+    @Test
+    fun testPidProviderSigningCertificateProfile() = pidSigningCertificateProfile().testCertificate(pidProviderSigningCertificate)
+
+    @Test
+    fun testWalletProviderSigningCertificateProfile() = walletProviderSigningCertificateProfile().testCertificate(walletProviderSigningCertificate)
+
+    @Test
+    fun testIssuerAccessCertificate() = wrpAccessCertificateProfile().testCertificate(issuerAccessCertificate)
+
+    @Test
+    fun testVerifierAccessCertificate() = wrpAccessCertificateProfile().testCertificate(verifierAccessCertificate)
 
     private fun CertificateProfile.testCertificate(pem: String) = runTest {
         val certificate = x509Certificate(pem)
         val evaluation = CertificateProfileValidatorJVM.validate(this@testCertificate, certificate)
         if (evaluation is CertificateConstraintEvaluation.Violated) {
             fail("Certificate validation failed: ${evaluation.violations.joinToString("\n")}")
+        }
+    }
+
+    @Test
+    @OptIn(SensitiveApi::class)
+    fun testCertificateTrust() = runTest {
+        createHttpClient().use { httpClient ->
+            val fileStore = LoTEFileStore(
+                cacheDirectory = Path(Files.createTempDirectory("ref-impl-lote").toString()),
+            )
+
+            val isChainTrustedForContext = isChainTrustedForContext(httpClient, fileStore)
+            isChainTrustedForContext.testCertificate(pidProviderSigningCertificate, VerificationContext.PID)
+            isChainTrustedForContext.testCertificate(walletProviderSigningCertificate, VerificationContext.WalletProviderAttestation)
+            isChainTrustedForContext.testCertificate(issuerAccessCertificate, VerificationContext.WalletRelyingPartyAccessCertificate)
+            isChainTrustedForContext.testCertificate(verifierAccessCertificate, VerificationContext.WalletRelyingPartyAccessCertificate)
+        }
+    }
+
+    private suspend fun IsChainTrustedForEUDIW<List<X509Certificate>, TrustAnchor>.testCertificate(pem: String, context: VerificationContext) {
+        val certificate = x509Certificate(pem)
+        val certificationChainValidation = invoke(listOf(certificate), context)
+            ?: error("Verification context $context has not been configured")
+
+        if (certificationChainValidation is CertificationChainValidation.NotTrusted) {
+            fail("Certificate could not be validated against context $context", certificationChainValidation.cause)
         }
     }
 

--- a/119602-consultation/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi119602/consultation/EUDIRefImplEnv.kt
+++ b/119602-consultation/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi119602/consultation/EUDIRefImplEnv.kt
@@ -26,14 +26,10 @@ import eu.europa.ec.eudi.etsi1196x2.consultation.certs.CertificateProfile
 import io.ktor.client.*
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.files.Path
-import java.io.ByteArrayInputStream
-import java.security.cert.CertificateFactory
 import java.security.cert.TrustAnchor
 import java.security.cert.X509Certificate
-import kotlin.io.encoding.Base64
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
-import kotlin.test.assertIs
 import kotlin.test.fail
 import kotlin.time.Duration.Companion.hours
 
@@ -131,30 +127,6 @@ class EUDIRefImplEnvTest {
         // Get the LoTEs, organized them as EUDIW verification contexts
         val provisionTrustAnchors = getTrustAnchorsProvisioner(loadLoTE, svcTypePerCtx = svcTypePerCtx)
         return provisionTrustAnchors.nonCached(EUDIRefImplEnv.LOTE_URL)
-    }
-
-    @Test
-    @SensitiveApi
-    fun verifyThatPidX5CIsTrustedForPIDContext() = runTest {
-        createHttpClient().use { httpClient ->
-            val fileStore = LoTEFileStore(
-                cacheDirectory = Path(System.getProperty("java.io.tmpdir")!!, "ref-impl-lote"),
-            )
-            val isChainTrustedForContext = isChainTrustedForContext(httpClient, fileStore).contraMap(::certsFromX5C)
-            val validation = isChainTrustedForContext(pidX5c, VerificationContext.PID)
-            assertIs<CertificationChainValidation.Trusted<TrustAnchor>>(validation)
-        }
-    }
-
-    private val pidX5c: List<String> =
-        listOf("MIIC3zCCAoWgAwIBAgIUf3lohTmDMAmS/YX/q4hqoRyJB54wCgYIKoZIzj0EAwIwXDEeMBwGA1UEAwwVUElEIElzc3VlciBDQSAtIFVUIDAyMS0wKwYDVQQKDCRFVURJIFdhbGxldCBSZWZlcmVuY2UgSW1wbGVtZW50YXRpb24xCzAJBgNVBAYTAlVUMB4XDTI1MDQxMDE0Mzc1MloXDTI2MDcwNDE0Mzc1MVowUjEUMBIGA1UEAwwLUElEIERTIC0gMDExLTArBgNVBAoMJEVVREkgV2FsbGV0IFJlZmVyZW5jZSBJbXBsZW1lbnRhdGlvbjELMAkGA1UEBhMCVVQwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAS7WAAWqPze0Us3z8pajyVPWBRmrRbCi5X2s9GvlybQytwTumcZnej9BkLfAglloX5tv+NgWfDfgt/06s+5tV4lo4IBLTCCASkwHwYDVR0jBBgwFoAUYseURyi9D6IWIKeawkmURPEB08cwGwYDVR0RBBQwEoIQaXNzdWVyLmV1ZGl3LmRldjAWBgNVHSUBAf8EDDAKBggrgQICAAABAjBDBgNVHR8EPDA6MDigNqA0hjJodHRwczovL3ByZXByb2QucGtpLmV1ZGl3LmRldi9jcmwvcGlkX0NBX1VUXzAyLmNybDAdBgNVHQ4EFgQUql/opxkQlYy0llaToPbDE/myEcEwDgYDVR0PAQH/BAQDAgeAMF0GA1UdEgRWMFSGUmh0dHBzOi8vZ2l0aHViLmNvbS9ldS1kaWdpdGFsLWlkZW50aXR5LXdhbGxldC9hcmNoaXRlY3R1cmUtYW5kLXJlZmVyZW5jZS1mcmFtZXdvcmswCgYIKoZIzj0EAwIDSAAwRQIhANJVSDsqT3IkGcKWWgSeubkDOdi5/UE9b1GF/X5fQRFaAiBp5t6tHh8XwFhPstzOHMopvBD/Gwms0RAUgmSn6ku8Gg==")
-
-    fun certsFromX5C(x5c: List<String>): List<X509Certificate> {
-        val factory = CertificateFactory.getInstance("X.509")
-        return x5c.map {
-            val decoded = Base64.decode(it)
-            factory.generateCertificate(ByteArrayInputStream(decoded)) as X509Certificate
-        }
     }
 
     @Test

--- a/119602-consultation/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi119602/consultation/EUDIRefImplEnv.kt
+++ b/119602-consultation/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi119602/consultation/EUDIRefImplEnv.kt
@@ -117,9 +117,9 @@ class EUDIRefImplEnvTest {
                 },
             )
             copy(
-                pidProviders = pidProviders?.noEndEntityProfile(),
-                walletProviders = walletProviders?.noEndEntityProfile(),
-                wrpacProviders = wrpacProviders?.noEndEntityProfile(),
+                pidProviders = pidProviders,
+                walletProviders = walletProviders,
+                wrpacProviders = wrpacProviders,
                 wrprcProviders = wrprcProviders?.noEndEntityProfile(),
                 pubEaaProviders = pubEaaProviders?.noEndEntityProfile(),
                 qeaProviders = qeaProviders?.noEndEntityProfile(),
@@ -134,23 +134,23 @@ class EUDIRefImplEnvTest {
     fun testPidProviderProfile() = pidSigningCertificateProfile().testCertificate(
         """
             -----BEGIN CERTIFICATE-----
-            MIIDADCCAqWgAwIBAgIUPYqmwQevpl4zHH0kInP2kmjornYwCgYIKoZIzj0EAwIw
+            MIIDADCCAqWgAwIBAgIUET5T0Zf8eiEGSYn1U4xFBedGXsswCgYIKoZIzj0EAwIw
             VzEZMBcGA1UEAwwQUElEIElzc3VlciBDQSAwMjEtMCsGA1UECgwkRVVESSBXYWxs
             ZXQgUmVmZXJlbmNlIEltcGxlbWVudGF0aW9uMQswCQYDVQQGEwJFVTAeFw0yNjA1
-            MDcxMDQ1MDRaFw0yODA1MDYxMDQ1MDNaMFcxCzAJBgNVBAYTAkVVMQ4wDAYDVQQK
-            DAVOaXNjeTEeMBwGA1UEAwwVUElEIFByb3ZpZGVyIERFViBFWCAyMRgwFgYDVQRh
-            DA9MRUlFVS0xMjM0NTY3ODkwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATGoyQ1
-            k+dsTicH9I/U7zYrnkujdyzBXPX+XzoSQzq3baTMLY3MWx6yj3jaeXAjz0ccWU0v
-            gDwo2bHKcQ/mkz4ao4IBTTCCAUkwDAYDVR0TAQH/BAIwADAfBgNVHSMEGDAWgBRC
+            MTQxMDM1MjVaFw0yODA1MTMxMDM1MjRaMFcxHjAcBgNVBAMMFUtvdGxpbiBQSUQg
+            SXNzdWVyIERFVjEYMBYGA1UEYQwPTEVJRVUtMTIzNDU2Nzg5MQ4wDAYDVQQKDAVO
+            aXNjeTELMAkGA1UEBhMCRVUwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQ9e6zs
+            PHWFwl+GJo6/TX2OfHgTtYpb+owtb4ssILvOZFwLFW6UPd5YidcOYDNH/r4fB+50
+            4igzpFHhn2na7GEMo4IBTTCCAUkwDAYDVR0TAQH/BAIwADAfBgNVHSMEGDAWgBRC
             UFC+ELgQ8J1EXI2/qxAI7ifcSTBZBggrBgEFBQcBAQRNMEswSQYIKwYBBQUHMAKG
             PWh0dHBzOi8vcHJlcHJvZC5wa2kuZXVkaXcuZGV2L2FpYS9QSURJc3N1ZXJDQTAy
             LUVVLmNhY2VydC5wZW0wLgYDVR0gBCcwJTAjBgMqAwQwHDAaBggrBgEFBQcCARYO
             ZXhhbXBsZS5wb2xpY3kwQwYDVR0fBDwwOjA4oDagNIYyaHR0cHM6Ly9wcmVwcm9k
-            LnBraS5ldWRpdy5kZXYvY3JsL3BpZF9DQV9FVV8wMi5jcmwwHQYDVR0OBBYEFE+L
-            ZfV8VC4akQ2J1kXpjr6AdHQSMA4GA1UdDwEB/wQEAwIHgDAZBggrBgEFBQcBAwQN
-            MAswCQYHBACL7E4BATAKBggqhkjOPQQDAgNJADBGAiEA9eyUPSrnG84Q134rsSkH
-            vCVI5zOksUqGnJtB9HaVHNECIQDBeW4UUk8jptkef6JRkAK52QOMGmIQ4bWZOZSe
-            Twb1Ag==
+            LnBraS5ldWRpdy5kZXYvY3JsL3BpZF9DQV9FVV8wMi5jcmwwHQYDVR0OBBYEFCII
+            oL5fiFXGYu65C0oT0w2FHWmkMA4GA1UdDwEB/wQEAwIHgDAZBggrBgEFBQcBAwQN
+            MAswCQYHBACL7E4BATAKBggqhkjOPQQDAgNJADBGAiEAymfJqRvn3bqToZEMxrku
+            PMIZjiKt9xplNamzAoTpv0kCIQCdzmncNLr51HhgGRZiPj7nolhJNoonoH6TkmZu
+            pJXe3A==
             -----END CERTIFICATE-----
         """.trimIndent(),
     )
@@ -183,50 +183,50 @@ class EUDIRefImplEnvTest {
     @Test
     fun testIssuerAccessCertificate() = wrpAccessCertificateProfile().testCertificate(
         """
-           -----BEGIN CERTIFICATE-----
-           MIIDAzCCAqqgAwIBAgIURqZMwltm47FnrUuswJZawUAjTtEwCgYIKoZIzj0EAwIw
-           VzEZMBcGA1UEAwwQUElEIElzc3VlciBDQSAwMjEtMCsGA1UECgwkRVVESSBXYWxs
-           ZXQgUmVmZXJlbmNlIEltcGxlbWVudGF0aW9uMQswCQYDVQQGEwJFVTAeFw0yNjA1
-           MDcxMzM3MzBaFw0yODA1MDYxMzM3MjlaMFoxITAfBgNVBAMMGEtvdGxpbiBJc3N1
-           ZXIgU2lnbmVyIERldjELMAkGA1UEBhMCRVUxDjAMBgNVBAoMBU5pc2N5MRgwFgYD
-           VQRhDA9MRUlFVS0xMjM0NTY3ODkwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQD
-           sy1vqh8TI7SUYY7OyZ0Tn08TaZPn+Zdw5BilTEVzXc6SSu0gAFkcaNKunRZB4JAk
-           luQ5YKi6DRPa3s8fcYGWo4IBTzCCAUswDAYDVR0TAQH/BAIwADAfBgNVHSMEGDAW
-           gBRCUFC+ELgQ8J1EXI2/qxAI7ifcSTBZBggrBgEFBQcBAQRNMEswSQYIKwYBBQUH
-           MAKGPWh0dHBzOi8vcHJlcHJvZC5wa2kuZXVkaXcuZGV2L2FpYS9QSURJc3N1ZXJD
-           QTAyLUVVLmNhY2VydC5wZW0wNQYDVR0RBC4wLIYqaHR0cHM6Ly9kZXYua290bGlu
-           SXNzdWVyU2lnbmVyLmNvbS9zdXBwb3J0MBQGA1UdIAQNMAswCQYHBACL7EYBAjBD
-           BgNVHR8EPDA6MDigNqA0hjJodHRwczovL3ByZXByb2QucGtpLmV1ZGl3LmRldi9j
-           cmwvcGlkX0NBX0VVXzAyLmNybDAdBgNVHQ4EFgQUwu8/c7hdHHi6rGE75pg3f4Yf
-           JSswDgYDVR0PAQH/BAQDAgeAMAoGCCqGSM49BAMCA0cAMEQCIDjAxHdaaRIc1CG3
-           oqbvYRbzIbMHoqNh2EUfLjLfsezLAiBPVXyUJQyJ/rE43aVgjB4tX5h8oAuQNEBS
-           G9WdPfYDrg==
-           -----END CERTIFICATE-----
+            -----BEGIN CERTIFICATE-----
+            MIIDAzCCAqqgAwIBAgIURqZMwltm47FnrUuswJZawUAjTtEwCgYIKoZIzj0EAwIw
+            VzEZMBcGA1UEAwwQUElEIElzc3VlciBDQSAwMjEtMCsGA1UECgwkRVVESSBXYWxs
+            ZXQgUmVmZXJlbmNlIEltcGxlbWVudGF0aW9uMQswCQYDVQQGEwJFVTAeFw0yNjA1
+            MDcxMzM3MzBaFw0yODA1MDYxMzM3MjlaMFoxITAfBgNVBAMMGEtvdGxpbiBJc3N1
+            ZXIgU2lnbmVyIERldjELMAkGA1UEBhMCRVUxDjAMBgNVBAoMBU5pc2N5MRgwFgYD
+            VQRhDA9MRUlFVS0xMjM0NTY3ODkwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAQD
+            sy1vqh8TI7SUYY7OyZ0Tn08TaZPn+Zdw5BilTEVzXc6SSu0gAFkcaNKunRZB4JAk
+            luQ5YKi6DRPa3s8fcYGWo4IBTzCCAUswDAYDVR0TAQH/BAIwADAfBgNVHSMEGDAW
+            gBRCUFC+ELgQ8J1EXI2/qxAI7ifcSTBZBggrBgEFBQcBAQRNMEswSQYIKwYBBQUH
+            MAKGPWh0dHBzOi8vcHJlcHJvZC5wa2kuZXVkaXcuZGV2L2FpYS9QSURJc3N1ZXJD
+            QTAyLUVVLmNhY2VydC5wZW0wNQYDVR0RBC4wLIYqaHR0cHM6Ly9kZXYua290bGlu
+            SXNzdWVyU2lnbmVyLmNvbS9zdXBwb3J0MBQGA1UdIAQNMAswCQYHBACL7EYBAjBD
+            BgNVHR8EPDA6MDigNqA0hjJodHRwczovL3ByZXByb2QucGtpLmV1ZGl3LmRldi9j
+            cmwvcGlkX0NBX0VVXzAyLmNybDAdBgNVHQ4EFgQUwu8/c7hdHHi6rGE75pg3f4Yf
+            JSswDgYDVR0PAQH/BAQDAgeAMAoGCCqGSM49BAMCA0cAMEQCIDjAxHdaaRIc1CG3
+            oqbvYRbzIbMHoqNh2EUfLjLfsezLAiBPVXyUJQyJ/rE43aVgjB4tX5h8oAuQNEBS
+            G9WdPfYDrg==
+            -----END CERTIFICATE-----
         """.trimIndent(),
     )
 
     @Test
     fun testVerifierAccessCertificate() = wrpAccessCertificateProfile().testCertificate(
         """
-                -----BEGIN CERTIFICATE-----
-                MIIC/TCCAqKgAwIBAgIUK/6I3nrQOiMq/aIqMF7D7vv+xA4wCgYIKoZIzj0EAwIw
-                VzEZMBcGA1UEAwwQUElEIElzc3VlciBDQSAwMjEtMCsGA1UECgwkRVVESSBXYWxs
-                ZXQgUmVmZXJlbmNlIEltcGxlbWVudGF0aW9uMQswCQYDVQQGEwJFVTAeFw0yNjA1
-                MDcxMzM4MzhaFw0yODA1MDYxMzM4MzdaMFUxHDAaBgNVBAMME1ZlcmlmaWVyIFNp
-                Z25lciBkZXYxCzAJBgNVBAYTAkVVMQ4wDAYDVQQKDAVOaXNjeTEYMBYGA1UEYQwP
-                TEVJRVUtMTIzNDU2Nzg5MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvZPdm4oz
-                0rYYexoyJSYU5YG0ZBMTUQRzSVZjo2y0gZYU2jpxwb8/Rk1Aeb2rcc98CfJONqky
-                a9p/wae5k7fChaOCAUwwggFIMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAUQlBQ
-                vhC4EPCdRFyNv6sQCO4n3EkwWQYIKwYBBQUHAQEETTBLMEkGCCsGAQUFBzAChj1o
-                dHRwczovL3ByZXByb2QucGtpLmV1ZGl3LmRldi9haWEvUElESXNzdWVyQ0EwMi1F
-                VS5jYWNlcnQucGVtMDIGA1UdEQQrMCmGJ2h0dHBzOi8vZGV2LnZlcmlmaWVyLWJh
-                Y2tlbmQuZXVkaXcuZGV2LzAUBgNVHSAEDTALMAkGBwQAi+xGAQIwQwYDVR0fBDww
-                OjA4oDagNIYyaHR0cHM6Ly9wcmVwcm9kLnBraS5ldWRpdy5kZXYvY3JsL3BpZF9D
-                QV9FVV8wMi5jcmwwHQYDVR0OBBYEFO+X15taOVBhkGJTBBt50FSN0zMPMA4GA1Ud
-                DwEB/wQEAwIHgDAKBggqhkjOPQQDAgNJADBGAiEApj2PCZqVuQwq/Wy6y5gf2tm4
-                XXYfyjgJS2jl6poPBK0CIQDOrjRS9rPbEK3MbUnQdcfZpRHCMeaT5+Fhqb+nrb89
-                cw==
-                -----END CERTIFICATE-----
+            -----BEGIN CERTIFICATE-----
+            MIIC/TCCAqKgAwIBAgIUK/6I3nrQOiMq/aIqMF7D7vv+xA4wCgYIKoZIzj0EAwIw
+            VzEZMBcGA1UEAwwQUElEIElzc3VlciBDQSAwMjEtMCsGA1UECgwkRVVESSBXYWxs
+            ZXQgUmVmZXJlbmNlIEltcGxlbWVudGF0aW9uMQswCQYDVQQGEwJFVTAeFw0yNjA1
+            MDcxMzM4MzhaFw0yODA1MDYxMzM4MzdaMFUxHDAaBgNVBAMME1ZlcmlmaWVyIFNp
+            Z25lciBkZXYxCzAJBgNVBAYTAkVVMQ4wDAYDVQQKDAVOaXNjeTEYMBYGA1UEYQwP
+            TEVJRVUtMTIzNDU2Nzg5MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvZPdm4oz
+            0rYYexoyJSYU5YG0ZBMTUQRzSVZjo2y0gZYU2jpxwb8/Rk1Aeb2rcc98CfJONqky
+            a9p/wae5k7fChaOCAUwwggFIMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAUQlBQ
+            vhC4EPCdRFyNv6sQCO4n3EkwWQYIKwYBBQUHAQEETTBLMEkGCCsGAQUFBzAChj1o
+            dHRwczovL3ByZXByb2QucGtpLmV1ZGl3LmRldi9haWEvUElESXNzdWVyQ0EwMi1F
+            VS5jYWNlcnQucGVtMDIGA1UdEQQrMCmGJ2h0dHBzOi8vZGV2LnZlcmlmaWVyLWJh
+            Y2tlbmQuZXVkaXcuZGV2LzAUBgNVHSAEDTALMAkGBwQAi+xGAQIwQwYDVR0fBDww
+            OjA4oDagNIYyaHR0cHM6Ly9wcmVwcm9kLnBraS5ldWRpdy5kZXYvY3JsL3BpZF9D
+            QV9FVV8wMi5jcmwwHQYDVR0OBBYEFO+X15taOVBhkGJTBBt50FSN0zMPMA4GA1Ud
+            DwEB/wQEAwIHgDAKBggqhkjOPQQDAgNJADBGAiEApj2PCZqVuQwq/Wy6y5gf2tm4
+            XXYfyjgJS2jl6poPBK0CIQDOrjRS9rPbEK3MbUnQdcfZpRHCMeaT5+Fhqb+nrb89
+            cw==
+            -----END CERTIFICATE-----
         """.trimIndent(),
     )
 

--- a/119602-consultation/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi119602/consultation/EUDIRefImplEnv.kt
+++ b/119602-consultation/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi119602/consultation/EUDIRefImplEnv.kt
@@ -26,6 +26,7 @@ import eu.europa.ec.eudi.etsi1196x2.consultation.certs.CertificateProfile
 import io.ktor.client.*
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.files.Path
+import java.nio.file.Files
 import java.security.cert.TrustAnchor
 import java.security.cert.X509Certificate
 import kotlin.test.Test
@@ -54,7 +55,7 @@ class EUDIRefImplEnvTest {
         createHttpClient().use { httpClient ->
 
             val fileStore = LoTEFileStore(
-                cacheDirectory = Path(System.getProperty("java.io.tmpdir")!!, "ref-impl-lote"),
+                cacheDirectory = Path(Files.createTempDirectory("ref-impl-lote").toString()),
             )
 
             val isChainTrustedForContext = isChainTrustedForContext(httpClient, fileStore)

--- a/119602-consultation/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi119602/consultation/jp/JPPoC.kt
+++ b/119602-consultation/src/jvmAndAndroidTest/kotlin/eu/europa/ec/eudi/etsi119602/consultation/jp/JPPoC.kt
@@ -28,6 +28,7 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.files.Path
+import java.nio.file.Files
 import java.security.cert.TrustAnchor
 import java.security.cert.X509Certificate
 import kotlin.test.Ignore
@@ -107,7 +108,7 @@ class JPLoTEDownloaderTest {
         createHttpClient().use { httpClient ->
 
             val fileStore = LoTEFileStore(
-                cacheDirectory = Path(System.getProperty("java.io.tmpdir")!!, "jp-lote"),
+                cacheDirectory = Path(Files.createTempDirectory("jp-lote").toString()),
             )
             val verifier = run {
                 val loadLoTE = LoadSingleLoTEWithFileCache(


### PR DESCRIPTION
This PR:

1. Updates the test certificates used in `EUDIRefImplEnv.kt`
2. Remove old and no longer used certificate
3. Enables end-entity Certificate Profile validations for `PID`, `WalletProviderAttestation`, and `WalletRelyingPartyAccessCertificate` LoTEs in `EUDIRefImplEnv.kt`
4. Add a new test case in `EUDIRefImplEnv.kt` to verify the test certificates are trusted when using the Ref. Implementation LoTEs.